### PR TITLE
Fix Rubocop style

### DIFF
--- a/lib/is_dark.rb
+++ b/lib/is_dark.rb
@@ -107,7 +107,7 @@ class IsDark
     end
     dark = true if points >= (dots.length / 100) * @percent
     if @with_debug
-      percent_calculated = points/(dots.length / 100)
+      percent_calculated = points / (dots.length / 100)
       p '=================================================================================='
       p "Total Points: #{dots.length}, dark points amount:#{points}"
       p "Is \"invert to white not detectd pixels\" option enabled?:#{@with_not_detected_as_white}"


### PR DESCRIPTION
Rubocop test is failed. I fixed style.
![Screenshot from 2025-03-06 14-39-15](https://github.com/user-attachments/assets/93d062a6-6da7-4749-8fbb-4c7ccd43c27e)
https://github.com/butteff/is_dark_ruby_gem/actions/runs/13080776520/job/36503645806:
```
Inspecting 5 files
..C..

Offenses:

lib/is_dark.rb:110:34: C: [Correctable] Layout/SpaceAroundOperators: Surrounding space missing for operator /.
      percent_calculated = points/(dots.length / 100)
                                 ^

5 files inspected, 1 offense detected, 1 offense autocorrectable
```